### PR TITLE
Fix link to mongo-jiva dashboard

### DIFF
--- a/src/app/modules/home/workloadstable/workloadstable.component.html
+++ b/src/app/modules/home/workloadstable/workloadstable.component.html
@@ -77,7 +77,7 @@
               'text-danger ':status === 'Pending' || status === 'Failed',
               'text-warning ':status === 'Unknown'
             }" ></i> {{status}}
-            <a href="https://mongojiva.test.openebs.io">Dashboard</a>
+            <a href="https://mongojiva.openebs.ci">Dashboard</a>
             </td>
           </tr>
         </table>

--- a/src/app/modules/home/workloadstable/workloadstable.component.ts
+++ b/src/app/modules/home/workloadstable/workloadstable.component.ts
@@ -15,7 +15,7 @@ export class WorkloadstableComponent implements OnInit {
   ngOnInit() {
 
     timer(0, 10000).subscribe(x => {
-    return this.http.get('https://mongojiva.test.openebs.io/api/pod/status')
+    return this.http.get('https://mongojiva.openebs.ci/api/pod/status')
       .subscribe(data => {
         console.log(data)
         this.ok = data;


### PR DESCRIPTION
This PR:
-  Updates the link to new mongo-jiva dashboard(**mongojiva.openebs.ci**)
Signed-off-by: Shivesh Abhishek <shivesh.abhishek@mayadata.io>